### PR TITLE
feat: hot-reload user presets via SIGUSR1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "signal-hook",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -2052,9 +2053,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdbus-sys"
@@ -3380,6 +3381,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ tokio = { version = "1.0", default-features = false, features = ["rt", "time", "
 [target.'cfg(target_os = "linux")'.dependencies]
 mpris = "2.0"
 
+# Unix: Signal handling for preset reload (SIGUSR1)
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.3"
+
 
 # macOS: Uses private MediaRemote framework bindings
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,6 +562,58 @@ fn start_fft_processing(
 }
 
 // ========================================================================
+// SIGNAL HANDLER THREAD (SIGUSR1 = reload presets)
+// ========================================================================
+//    Listens for SIGUSR1 and reloads all user presets (colors + visuals).
+//    This is the standard Unix pattern for config reload — works reliably
+//    with symlinks, NixOS store paths, and any file management approach.
+
+#[cfg(unix)]
+fn start_signal_handler(
+    shared_state: Arc<Mutex<SharedState>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    thread::spawn(move || {
+        tracing::info!("[Presets] SIGUSR1 handler registered for preset reload");
+
+        let mut signals = match signal_hook::iterator::Signals::new([signal_hook::consts::SIGUSR1]) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("[Presets] Failed to register SIGUSR1 handler: {}", e);
+                return;
+            }
+        };
+
+        for _ in signals.forever() {
+            if shutdown.load(Ordering::Relaxed) {
+                break;
+            }
+            let color_presets = shared_state::AppConfig::load_user_color_presets();
+            let visual_presets = shared_state::AppConfig::load_user_visual_presets();
+            if let Ok(mut state) = shared_state.lock() {
+                tracing::info!(
+                    "[Presets] SIGUSR1: reloaded {} color, {} visual presets",
+                    color_presets.len(),
+                    visual_presets.len()
+                );
+                state.user_color_presets = color_presets;
+                state.user_visual_presets = visual_presets;
+            }
+        }
+
+        tracing::info!("[Presets] Signal handler shutdown");
+    });
+}
+
+#[cfg(not(unix))]
+fn start_signal_handler(
+    _shared_state: Arc<Mutex<SharedState>>,
+    _shutdown: Arc<AtomicBool>,
+) {
+    tracing::info!("[Presets] Signal-based reload not available on this platform");
+}
+
+// ========================================================================
 // Load Icon to Memory
 // ========================================================================
 fn load_icon() -> Option<Arc<egui::IconData>> {
@@ -688,6 +740,11 @@ fn main (){
     let media_manager = Arc::new(PlatformMedia::new());
     let (media_tx, media_rx) = bounded(10);
     media_manager.start(media_tx);
+
+    // ==================================
+    // Start Signal Handler Thread (SIGUSR1 = reload presets)
+    // ==================================
+    start_signal_handler(shared_state.clone(), shutdown.clone());
 
     // ==================================
     // Start Update Update Checker Thread

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -745,11 +745,112 @@ mod tests {
     // Critical: Prevents file system errors or overwrites
     #[test]
     fn test_filename_sanitization() {
-        // We need to access the private helper. 
+        // We need to access the private helper.
         // Rust unit tests in the same file CAN access private methods.
         assert_eq!(AppConfig::sanitize_filename("Cool Preset"), "cool_preset");
         assert_eq!(AppConfig::sanitize_filename("My/Preset!"), "mypreset");
         assert_eq!(AppConfig::sanitize_filename("  Trim Me  "), "trim_me");
         assert_eq!(AppConfig::sanitize_filename("O'Reilly"), "oreilly");
+    }
+
+    // --- 4. Preset Hot-Reload Tests ---
+    // Verifies that color presets can be loaded from a temp directory,
+    // updated on disk, and re-loaded with new values.
+
+    #[test]
+    fn test_color_preset_save_and_load_roundtrip() {
+        let dir = std::env::temp_dir().join("bespec_test_presets_roundtrip");
+        let colors_dir = dir.join("presets").join("colors");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&colors_dir).unwrap();
+
+        let preset = ColorProfile {
+            name: "test_roundtrip".to_string(),
+            low: Color32::from_rgb(10, 20, 30),
+            high: Color32::from_rgb(40, 50, 60),
+            peak: Color32::from_rgb(255, 0, 0),
+            background: Color32::BLACK,
+            text: Color32::WHITE,
+            inspector_bg: Color32::BLACK,
+            inspector_fg: Color32::WHITE,
+        };
+
+        let json = serde_json::to_string_pretty(&preset).unwrap();
+        fs::write(colors_dir.join("test_roundtrip.json"), &json).unwrap();
+
+        let loaded: ColorProfile =
+            serde_json::from_str(&fs::read_to_string(colors_dir.join("test_roundtrip.json")).unwrap())
+                .unwrap();
+
+        assert_eq!(loaded.name, "test_roundtrip");
+        assert_eq!(loaded.low, Color32::from_rgb(10, 20, 30));
+        assert_eq!(loaded.peak, Color32::from_rgb(255, 0, 0));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_color_preset_update_detected() {
+        let dir = std::env::temp_dir().join("bespec_test_presets_update");
+        let colors_dir = dir.join("presets").join("colors");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&colors_dir).unwrap();
+
+        // Write initial preset
+        let preset_v1 = ColorProfile {
+            name: "theme_test".to_string(),
+            low: Color32::from_rgb(0, 0, 0),
+            ..ColorProfile::default()
+        };
+        let json_v1 = serde_json::to_string_pretty(&preset_v1).unwrap();
+        fs::write(colors_dir.join("theme_test.json"), &json_v1).unwrap();
+
+        // Load and verify v1
+        let content = fs::read_to_string(colors_dir.join("theme_test.json")).unwrap();
+        let loaded_v1: ColorProfile = serde_json::from_str(&content).unwrap();
+        assert_eq!(loaded_v1.low, Color32::from_rgb(0, 0, 0));
+
+        // Update the preset (simulates external theme manager writing new colors)
+        let preset_v2 = ColorProfile {
+            name: "theme_test".to_string(),
+            low: Color32::from_rgb(100, 200, 50),
+            ..ColorProfile::default()
+        };
+        let json_v2 = serde_json::to_string_pretty(&preset_v2).unwrap();
+        fs::write(colors_dir.join("theme_test.json"), &json_v2).unwrap();
+
+        // Re-load and verify v2
+        let content = fs::read_to_string(colors_dir.join("theme_test.json")).unwrap();
+        let loaded_v2: ColorProfile = serde_json::from_str(&content).unwrap();
+        assert_eq!(loaded_v2.low, Color32::from_rgb(100, 200, 50),
+            "Preset should reflect updated file contents");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_resolve_colors_picks_up_new_preset() {
+        // Simulates what happens after hot-reload: new user preset replaces old one
+        let old_presets = vec![ColorProfile {
+            name: "vogix theme".to_string(),
+            low: Color32::from_rgb(0, 100, 150), // blue
+            ..ColorProfile::default()
+        }];
+
+        let new_presets = vec![ColorProfile {
+            name: "vogix theme".to_string(),
+            low: Color32::from_rgb(100, 50, 0), // brown (walnut)
+            ..ColorProfile::default()
+        }];
+
+        let mut config = AppConfig::default();
+        config.profile.color_link = ColorRef::Preset("vogix theme".to_string());
+
+        let resolved_old = config.resolve_colors(&old_presets);
+        assert_eq!(resolved_old.low, Color32::from_rgb(0, 100, 150));
+
+        let resolved_new = config.resolve_colors(&new_presets);
+        assert_eq!(resolved_new.low, Color32::from_rgb(100, 50, 0),
+            "resolve_colors should use the latest preset data");
     }
 }


### PR DESCRIPTION
## Summary

Add signal-based preset reloading: sending SIGUSR1 to the bespec process reloads all user presets (colors + visuals) from disk.

## Why signals instead of file watching?

The original approach used the `notify` crate (inotify) to watch preset directories. This has a fundamental limitation: inotify doesn't detect content changes through symlinks. Theme managers like vogix on NixOS use symlinks to manage config files, so inotify-based watching silently fails.

SIGUSR1 is the standard Unix pattern for config reload (used by btop, tmux, sway, etc.). It works reliably regardless of how files are managed — symlinks, bind mounts, nix store paths, or regular files.

## Changes

- Add SIGUSR1 handler thread using `signal-hook` crate
- Reload both color and visual presets on signal receipt
- Replace `notify` crate with `signal-hook` (smaller, no inotify issues)
- No-op on non-Unix platforms

## Usage

```bash
# Reload presets after updating files
kill -USR1 $(pgrep bespec)
```

Theme managers send the signal automatically after updating preset files.

Closes #27