### PR TITLE
feat: VU coloring mode (gradient, retro)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,33 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    cargo
+    rustc
+    pkg-config
+    alsa-lib
+
+    # GPU / Wayland / X11 runtime libs (needed by egui/glow)
+    libglvnd
+    libxkbcommon
+    wayland
+    vulkan-loader
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXrandr
+    pipewire.jack
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+    pkgs.libglvnd
+    pkgs.libxkbcommon
+    pkgs.wayland
+    pkgs.vulkan-loader
+    pkgs.xorg.libX11
+    pkgs.xorg.libXcursor
+    pkgs.xorg.libXi
+    pkgs.xorg.libXrandr
+    pkgs.pipewire.jack
+  ];
+}

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -86,6 +86,104 @@ pub fn lerp_color(a: egui::Color32, b: egui::Color32, t: f32) -> egui::Color32 {
     )
 }
 
+/// Retro VU meter coloring: 3 discrete color zones instead of a smooth gradient.
+///
+/// Mimics classic hardware spectrum analyzers with distinct color bands:
+/// - 0–70%:  `low` color  (normal operating level)
+/// - 70–90%: `high` color (warning / elevated level)
+/// - 90–100%: `peak` color (danger / clipping zone)
+pub fn retro_color(low: egui::Color32, high: egui::Color32, peak: egui::Color32, t: f32) -> egui::Color32 {
+    if t < 0.7 { low }
+    else if t < 0.9 { high }
+    else { peak }
+}
+
+/// Choose the appropriate bar color based on the profile's `vu_coloring` setting.
+///
+/// - Retro mode: 3 discrete color zones via [`retro_color`].
+/// - Gradient mode: smooth linear interpolation via [`lerp_color`].
+pub fn bar_color(
+    low: egui::Color32,
+    high: egui::Color32,
+    peak: egui::Color32,
+    t: f32,
+    vu_coloring: crate::shared_state::VuColoring,
+) -> egui::Color32 {
+    match vu_coloring {
+        crate::shared_state::VuColoring::Retro => retro_color(low, high, peak, t),
+        crate::shared_state::VuColoring::Gradient => lerp_color(low, high, t),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retro_color_low_zone() {
+        let low = Color32::from_rgb(0, 255, 0);
+        let high = Color32::from_rgb(255, 255, 0);
+        let peak = Color32::from_rgb(255, 0, 0);
+
+        assert_eq!(retro_color(low, high, peak, 0.0), low);
+        assert_eq!(retro_color(low, high, peak, 0.35), low);
+        assert_eq!(retro_color(low, high, peak, 0.69), low);
+    }
+
+    #[test]
+    fn test_retro_color_high_zone() {
+        let low = Color32::from_rgb(0, 255, 0);
+        let high = Color32::from_rgb(255, 255, 0);
+        let peak = Color32::from_rgb(255, 0, 0);
+
+        assert_eq!(retro_color(low, high, peak, 0.7), high);
+        assert_eq!(retro_color(low, high, peak, 0.8), high);
+        assert_eq!(retro_color(low, high, peak, 0.89), high);
+    }
+
+    #[test]
+    fn test_retro_color_peak_zone() {
+        let low = Color32::from_rgb(0, 255, 0);
+        let high = Color32::from_rgb(255, 255, 0);
+        let peak = Color32::from_rgb(255, 0, 0);
+
+        assert_eq!(retro_color(low, high, peak, 0.9), peak);
+        assert_eq!(retro_color(low, high, peak, 0.95), peak);
+        assert_eq!(retro_color(low, high, peak, 1.0), peak);
+    }
+
+    #[test]
+    fn test_bar_color_retro_dispatches_to_retro() {
+        use crate::shared_state::VuColoring;
+        let low = Color32::from_rgb(0, 255, 0);
+        let high = Color32::from_rgb(255, 255, 0);
+        let peak = Color32::from_rgb(255, 0, 0);
+
+        assert_eq!(bar_color(low, high, peak, 0.5, VuColoring::Retro), low);
+    }
+
+    #[test]
+    fn test_bar_color_gradient_dispatches_to_lerp() {
+        use crate::shared_state::VuColoring;
+        let low = Color32::from_rgb(0, 0, 0);
+        let high = Color32::from_rgb(255, 255, 255);
+        let peak = Color32::from_rgb(255, 0, 0);
+
+        let result = bar_color(low, high, peak, 0.5, VuColoring::Gradient);
+        assert_ne!(result, low);
+        assert_ne!(result, high);
+    }
+
+    #[test]
+    fn test_lerp_color_endpoints() {
+        let a = Color32::from_rgb(0, 0, 0);
+        let b = Color32::from_rgb(255, 255, 255);
+
+        assert_eq!(lerp_color(a, b, 0.0).r(), 0);
+        assert_eq!(lerp_color(a, b, 1.0).r(), 255);
+    }
+}
+
 pub fn to_egui_font(font_variant: &ThemeFont) -> FontId {
     match font_variant {
         ThemeFont::Mini => FontId::new(9.0, FontFamily::Proportional),

--- a/src/gui/visualizers.rs
+++ b/src/gui/visualizers.rs
@@ -2,7 +2,7 @@ use egui::{Painter, Rect, Stroke};
 use crate::media::MediaController;
 use crate::shared_state::{ColorProfile, PerformanceStats, VisualMode, 
     VisualProfile, VisualizationData, MediaDisplayMode};
-use crate::gui::theme::{to_egui_color, db_to_px, lerp_color};
+use crate::gui::theme::{to_egui_color, db_to_px, lerp_color, bar_color};
 use crate::gui::widgets::draw_transport_controls;
 use crate::fft_processor::FFTProcessor;
 
@@ -177,32 +177,54 @@ pub fn draw_solid_bars(
         // Map audio dB to a physical screen dimension
         let bar_v = db_to_px(db, noise_floor_db, max_v);
         let norm_height = (bar_v / max_v).clamp(0.0, 1.0);
-        
-        // Calculate gradient coloring
-        let mut bar_color = lerp_color(low, high, norm_height);
-        if Some(i) == hovered_index {
-            bar_color = lerp_color(bar_color, egui::Color32::WHITE, 0.5);
-        }
 
-        // Map logical u/v coordinates to physical x/y coordinates based on user orientation
-        let p_base_left = map_uv_to_xy(rect, u, 0.0, profile.orientation);
-        let p_base_right = map_uv_to_xy(rect, u + bar_width, 0.0, profile.orientation);
-        let p_tip_right = map_uv_to_xy(rect, u + bar_width, bar_v, profile.orientation);
-        let p_tip_left = map_uv_to_xy(rect, u, bar_v, profile.orientation);
+        let is_hovered = Some(i) == hovered_index;
 
-        // Construct and submit the immmediate-mode mesh for this bar
         use egui::epaint::Vertex;
-        let mut mesh = egui::Mesh::default();
 
-        let v_idx = mesh.vertices.len() as u32;
-        mesh.vertices.push(Vertex { pos: p_base_left, uv: egui::Pos2::ZERO, color: low });
-        mesh.vertices.push(Vertex { pos: p_base_right, uv: egui::Pos2::ZERO, color: low });
-        mesh.vertices.push(Vertex { pos: p_tip_right, uv: egui::Pos2::ZERO, color: bar_color });
-        mesh.vertices.push(Vertex { pos: p_tip_left, uv: egui::Pos2::ZERO, color: bar_color });
-        
-        mesh.add_triangle(v_idx, v_idx + 1, v_idx + 2);
-        mesh.add_triangle(v_idx, v_idx + 2, v_idx + 3);
-        painter.add(egui::Shape::mesh(mesh));
+        if profile.vu_coloring == crate::shared_state::VuColoring::Retro {
+            if bar_v <= 0.0 { continue; }
+            // Retro mode: draw up to 3 discrete color zones within each bar
+            let zone_boundaries: &[(f32, egui::Color32)] = &[
+                (0.7, low),   // 0–70%: low
+                (0.9, high),  // 70–90%: high
+                (1.0, peak),  // 90–100%: peak
+            ];
+            let mut zone_start_v = 0.0_f32;
+            for &(zone_end_norm, zone_color) in zone_boundaries {
+                let zone_end_v = (zone_end_norm * max_v).min(bar_v);
+                if zone_start_v >= bar_v { break; }
+                let mut color = zone_color;
+                if is_hovered { color = lerp_color(color, egui::Color32::WHITE, 0.5); }
+
+                let p1 = map_uv_to_xy(rect, u, zone_start_v, profile.orientation);
+                let p2 = map_uv_to_xy(rect, u + bar_width, zone_end_v, profile.orientation);
+                let zone_rect = egui::Rect::from_two_pos(p1, p2);
+                painter.rect_filled(zone_rect, 0.0, color);
+
+                zone_start_v = zone_end_v;
+            }
+        } else {
+            // Gradient mode: GPU-interpolated smooth gradient from low to tip color
+            let mut color = bar_color(low, high, peak, norm_height, profile.vu_coloring);
+            if is_hovered { color = lerp_color(color, egui::Color32::WHITE, 0.5); }
+
+            let p_base_left = map_uv_to_xy(rect, u, 0.0, profile.orientation);
+            let p_base_right = map_uv_to_xy(rect, u + bar_width, 0.0, profile.orientation);
+            let p_tip_right = map_uv_to_xy(rect, u + bar_width, bar_v, profile.orientation);
+            let p_tip_left = map_uv_to_xy(rect, u, bar_v, profile.orientation);
+
+            let mut mesh = egui::Mesh::default();
+            let v_idx = mesh.vertices.len() as u32;
+            mesh.vertices.push(Vertex { pos: p_base_left, uv: egui::Pos2::ZERO, color: low });
+            mesh.vertices.push(Vertex { pos: p_base_right, uv: egui::Pos2::ZERO, color: low });
+            mesh.vertices.push(Vertex { pos: p_tip_right, uv: egui::Pos2::ZERO, color: color });
+            mesh.vertices.push(Vertex { pos: p_tip_left, uv: egui::Pos2::ZERO, color: color });
+
+            mesh.add_triangle(v_idx, v_idx + 1, v_idx + 2);
+            mesh.add_triangle(v_idx, v_idx + 2, v_idx + 3);
+            painter.add(egui::Shape::mesh(mesh));
+        }
 
         // Peaks
         if profile.show_peaks && i < data.peaks.len() {
@@ -346,9 +368,11 @@ pub fn draw_segmented_bars(
                 let segment_idx = s as f32;
                 let v_offset = segment_idx * total_seg_h;
                 
-                // Calculate gradient color based on vertical position
-                let norm_h = (v_offset / max_v).clamp(0.0, 1.0);
-                let color = lerp_color(low, high, norm_h);
+                // Calculate segment color (gradient or retro VU meter zones)
+                // Use segment midpoint for zone classification to avoid off-by-one at boundaries
+                let seg_center_v = v_offset + seg_h / 2.0;
+                let norm_h = (seg_center_v / max_v).clamp(0.0, 1.0);
+                let color = bar_color(low, high, peak_color, norm_h, profile.vu_coloring);
 
                 // Map logical bounds to physical rect
                 let p1 = map_uv_to_xy(rect, u, v_offset, profile.orientation);

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -2,7 +2,7 @@ use eframe::egui::{self, Ui, Rect, Context, Color32};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use crate::shared_state::{SharedState};
-use crate::shared_state::{ColorProfile, MediaDisplayMode, VisualMode, VisualProfile};
+use crate::shared_state::{ColorProfile, MediaDisplayMode, VisualMode, VisualProfile, VuColoring};
 use crate::shared_state::ColorRef;use crate::media::MediaController;
 use crate::gui::{theme::*, visualizers};
 
@@ -564,7 +564,18 @@ pub fn settings_tab_visual(
                         ui.selectable_value(&mut state.config.profile.visual_mode, VisualMode::Oscilloscope, "Oscilloscope");
                     });
                 ui.end_row();
-                
+
+                if state.config.profile.visual_mode != VisualMode::Oscilloscope {
+                    ui.label("VU Coloring");
+                    egui::ComboBox::from_id_salt("vu_coloring")
+                        .selected_text(format!("{:?}", state.config.profile.vu_coloring))
+                        .show_ui(ui, |ui| {
+                            ui.selectable_value(&mut state.config.profile.vu_coloring, VuColoring::Gradient, "Gradient");
+                            ui.selectable_value(&mut state.config.profile.vu_coloring, VuColoring::Retro, "Retro");
+                        });
+                    ui.end_row();
+                }
+
                 // Specific Controls
                 if state.config.profile.visual_mode != VisualMode::Oscilloscope {
                     ui.label("Bar Count");

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,4 +1,4 @@
-use crate::shared_state::{Color32, ColorProfile, ColorRef, ThemeFont, VisualMode, VisualProfile};
+use crate::shared_state::{Color32, ColorProfile, ColorRef, ThemeFont, VisualMode, VisualProfile, VuColoring};
 
 /// Returns all built-in Color Profiles
 pub fn built_in_colors() -> Vec<ColorProfile> {
@@ -537,13 +537,14 @@ pub fn built_in_visuals() -> Vec<VisualProfile> {
         VisualProfile {
             name: "Retro Dashboard".to_string(),
             visual_mode: VisualMode::SegmentedBars,
-            num_bars: 64, 
+            num_bars: 64,
             segment_height_px: 6.0,
             segment_gap_px: 2.0,
             overlay_font: ThemeFont::Monospace,
             color_link: ColorRef::Preset("Neon Tokyo".to_string()),
             attack_time_ms: 10.0,
             release_time_ms: 120.0,
+            vu_coloring: VuColoring::Retro,
             ..VisualProfile::default()
         },
 

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -44,6 +44,21 @@ impl Default for Orientation {
     }
 }
 
+/// Controls how bar colors are mapped across the frequency spectrum.
+#[derive(Clone, Copy, PartialEq, Serialize, Deserialize, Debug)]
+pub enum VuColoring {
+    /// Smooth linear interpolation from `low` to `high` color.
+    Gradient,
+    /// Classic 3-zone VU meter: low (0–70%), high (70–90%), peak (90–100%).
+    Retro,
+}
+
+impl Default for VuColoring {
+    fn default() -> Self {
+        Self::Gradient
+    }
+}
+
 
 /// Controls how the "Now Playing" media overlay behaves.
 #[derive(Clone, Copy, PartialEq, Serialize, Deserialize, Debug)]
@@ -177,6 +192,10 @@ pub struct VisualProfile {
     pub peak_release_time_ms: f32,
     pub aggregation_mode: AggregationMode,
 
+    // === Color Mode ===
+    #[serde(default)]
+    pub vu_coloring: VuColoring,
+
     // === Color Link ===
     pub color_link: ColorRef,
 
@@ -208,6 +227,7 @@ impl Default for VisualProfile {
             peak_hold_time_ms: 1000.0,
             peak_release_time_ms: 1500.0,
             aggregation_mode: AggregationMode::Peak,
+            vu_coloring: VuColoring::Gradient,
 
             color_link: ColorRef::Preset("Default".to_string()),
 


### PR DESCRIPTION
## Summary
- New **VU Coloring** setting in Visual tab with two modes: **Gradient** (default) and **Retro**
- Gradient mode smoothly interpolates bar color from low to high
- Retro mode splits each bar into 3 discrete color zones — low (0–70%), high (70–90%), peak (90–100%) — like classic hardware VU meters
- Works with both solid and segmented bar visualizers
- Retro Dashboard preset defaults to retro mode
- Includes `shell.nix` for Nix-based dev environment

## Test plan
- [x] Open Settings → Visual tab, verify VU Coloring dropdown appears for SolidBars, SegmentedBars, and LineSpectrum modes
- [x] Switch to Gradient — bars show smooth color interpolation
- [x] Switch to Retro — bars show 3 discrete color zones
- [x] Verify SolidBars in Retro mode draws zones within each bar (not flat single color)
- [x] Load Retro Dashboard preset — should default to Retro coloring
- [x] Verify dropdown is hidden for Oscilloscope mode
- [x] Verify old configs without `vu_coloring` field load correctly (defaults to Gradient)