### PR TITLE
feat(linux): native PipeWire audio capture backend

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,13 +23,24 @@ jobs:
     - uses: actions/checkout@v4
 
     # === COMBINED LINUX DEPENDENCIES ===
-    # Merges your original GUI deps (udev, wayland, xkb) 
-    # with the new Media deps (dbus, pkg-config)
+    # GUI deps (udev, wayland, xkb), media deps (dbus, pkg-config),
+    # plus the native PipeWire audio capture backend's compile-time deps:
+    #   - libpipewire-0.3-dev: libspa-sys / pipewire-sys link against this
+    #   - libclang-dev:        bindgen (used by libspa-sys) needs libclang
+    #                          to parse the pipewire C headers
     - name: Install Linux Dependencies
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev libdbus-1-dev pkg-config
+        sudo apt-get install -y \
+          libasound2-dev \
+          libudev-dev \
+          libwayland-dev \
+          libxkbcommon-dev \
+          libdbus-1-dev \
+          libpipewire-0.3-dev \
+          libclang-dev \
+          pkg-config
 
     # Cache cargo registry and build artifacts to speed up future runs
     - name: Cache Cargo registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "mpris",
  "num-complex",
  "open",
+ "pipewire",
  "realfft",
  "semver",
  "serde",
@@ -231,6 +232,22 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -499,6 +516,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
@@ -703,7 +721,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -760,7 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -818,6 +846,21 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "core-foundation"
@@ -1028,7 +1071,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ac8859845146979953797f03cc5b282fb4396891807cdb3d04929a88418197"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "quote 0.3.15",
  "syn 0.11.11",
 ]
@@ -1775,6 +1818,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2137,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
+dependencies = [
+ "bitflags 2.10.0",
+ "cc",
+ "convert_case",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nix 0.30.1",
+ "nom 8.0.0",
+ "system-deps",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901049455d2eb6decf9058235d745237952f4804bc584c5fcb41412e6adcc6e0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "system-deps",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2410,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2435,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2880,6 +2978,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pipewire"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix 0.30.1",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb028afee0d6ca17020b090e3b8fa2d7de23305aef975c7e5192a5050246ea36"
+dependencies = [
+ "bindgen",
+ "libspa-sys",
+ "system-deps",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +3483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,6 +3735,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,10 +3911,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -3772,19 +3950,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -3922,6 +4106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,6 +4170,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -4874,12 +5070,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
 name = "winres"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -5012,7 +5214,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
- "nix",
+ "nix 0.29.0",
  "ordered-stream",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ winres = "0.1"
 
 [dependencies]
 # Audio capture and processing
-cpal = "0.15"
 realfft = "3.3"
 num-complex = "0.4"
 directories = "5.0"
@@ -56,9 +55,18 @@ windows = { version = "0.52", features = [
 ] }
 tokio = { version = "1.0", default-features = false, features = ["rt", "time", "sync"] }
 
-# Linux: Uses the MPRIS standard via D-Bus
+# Linux: Uses the MPRIS standard via D-Bus, and PipeWire native for audio capture
 [target.'cfg(target_os = "linux")'.dependencies]
 mpris = "2.0"
+# v0_3_44 feature enables PW_KEY_TARGET_OBJECT (added in pipewire 0.3.44)
+# which we use to pin a capture stream to a specific sink/source by name.
+pipewire = { version = "0.9", features = ["v0_3_44"] }
+
+# Non-Linux: cpal handles audio capture (its WASAPI loopback / CoreAudio paths
+# work properly on Windows / macOS — only Linux's ALSA backend is broken for our
+# "capture what's playing" use case, so we go native there).
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+cpal = "0.15"
 
 # Unix: Signal handling for preset reload (SIGUSR1)
 [target.'cfg(unix)'.dependencies]

--- a/examples/list-pw-sources.rs
+++ b/examples/list-pw-sources.rs
@@ -1,0 +1,152 @@
+//! Standalone diagnostic that lists every Audio/Source node visible to
+//! PipeWire, classified into output monitors (i.e. "what's playing on this
+//! sink") and physical inputs (mics, line-ins). Exists so the linux audio
+//! enumeration can be tested without rebuilding bespec or launching the GUI.
+//!
+//! Run with:
+//!
+//!     cargo run --release --example list-pw-sources
+//!
+//! This is a self-contained reference implementation of the same registry
+//! walk used by `audio_capture_pw::enumerate_pipewire_sources()`. Linux only —
+//! on macOS / Windows the bespec audio backend uses cpal so this example
+//! short-circuits to a friendly "linux only" message. The crate-level `main`
+//! function still has to exist on every platform or cargo refuses to build
+//! the example, hence the cfg-gated-body / stub-main split below.
+
+#[cfg(target_os = "linux")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use pipewire as pw;
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum SourceType {
+        Monitor,
+        Input,
+    }
+
+    #[derive(Debug)]
+    struct Source {
+        node_name: String,
+        description: String,
+        source_type: SourceType,
+    }
+
+    pw::init();
+
+    let mainloop = pw::main_loop::MainLoopRc::new(None)?;
+    let context = pw::context::ContextRc::new(&mainloop, None)?;
+    let core = context.connect_rc(None)?;
+    let registry = core.get_registry_rc()?;
+
+    let sources: Rc<RefCell<Vec<Source>>> = Rc::new(RefCell::new(Vec::new()));
+    let sources_for_global = Rc::clone(&sources);
+
+    // Standard pipewire-rs roundtrip pattern: fire `core.sync(0)` first so
+    // the seq id can be moved into the done listener without a Cell, then
+    // install the listeners and drive the loop until done.
+    let pending = core.sync(0)?;
+    let done = Rc::new(Cell::new(false));
+    let done_for_listener = Rc::clone(&done);
+    let mainloop_for_listener = mainloop.clone();
+
+    let _core_listener = core
+        .add_listener_local()
+        .done(move |id, seq| {
+            if id == pw::core::PW_ID_CORE && seq == pending {
+                done_for_listener.set(true);
+                mainloop_for_listener.quit();
+            }
+        })
+        .register();
+
+    let _registry_listener = registry
+        .add_listener_local()
+        .global(move |obj| {
+            if obj.type_ != pw::types::ObjectType::Node {
+                return;
+            }
+            let Some(props) = obj.props.as_ref() else {
+                return;
+            };
+            let Some(media_class) = props.get("media.class") else {
+                return;
+            };
+            let Some(node_name) = props.get("node.name") else {
+                return;
+            };
+            let description = props
+                .get("node.description")
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| node_name.to_string());
+
+            match media_class {
+                // Physical inputs and any monitors that the pipewire-pulse
+                // compat layer happens to materialize as standalone sources.
+                "Audio/Source" => {
+                    let source_type = if node_name.ends_with(".monitor") {
+                        SourceType::Monitor
+                    } else {
+                        SourceType::Input
+                    };
+                    sources_for_global.borrow_mut().push(Source {
+                        node_name: node_name.to_string(),
+                        description,
+                        source_type,
+                    });
+                }
+                // Sinks: synthesize a monitor entry. PipeWire doesn't publish
+                // monitors as standalone Audio/Source globals — the monitor
+                // is an implicit aspect of the sink that you reach by
+                // targeting the sink's node name with STREAM_CAPTURE_SINK.
+                "Audio/Sink" => {
+                    sources_for_global.borrow_mut().push(Source {
+                        node_name: node_name.to_string(),
+                        description,
+                        source_type: SourceType::Monitor,
+                    });
+                }
+                _ => {}
+            }
+        })
+        .register();
+
+    while !done.get() {
+        mainloop.run();
+    }
+
+    let sources = sources.borrow();
+    let monitors: Vec<&Source> = sources
+        .iter()
+        .filter(|s| s.source_type == SourceType::Monitor)
+        .collect();
+    let inputs: Vec<&Source> = sources
+        .iter()
+        .filter(|s| s.source_type == SourceType::Input)
+        .collect();
+
+    println!("─── Outputs (visualize playback) ─── [{} found]", monitors.len());
+    for s in &monitors {
+        println!("  🔊 {}", s.description);
+        println!("       node.name = {}", s.node_name);
+    }
+    println!();
+    println!("─── Inputs (visualize a microphone or line-in) ─── [{} found]", inputs.len());
+    for s in &inputs {
+        println!("  🎤 {}", s.description);
+        println!("       node.name = {}", s.node_name);
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "list-pw-sources is a linux-only diagnostic for the native PipeWire \
+         audio backend; on this platform bespec uses cpal and there's nothing \
+         to enumerate via PipeWire."
+    );
+    std::process::exit(2);
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,18 @@
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.mkShell {
-  buildInputs = with pkgs; [
+  nativeBuildInputs = with pkgs; [
     cargo
     rustc
     pkg-config
+    gcc
+    clang
+  ];
+
+  buildInputs = with pkgs; [
     alsa-lib
+    dbus
+    pipewire
 
     # GPU / Wayland / X11 runtime libs (needed by egui/glow)
     libglvnd
@@ -19,6 +26,9 @@ pkgs.mkShell {
     pipewire.jack
   ];
 
+  # libspa-sys / pipewire-sys use bindgen → need libclang at compile time
+  LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+
   LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
     pkgs.libglvnd
     pkgs.libxkbcommon
@@ -28,6 +38,7 @@ pkgs.mkShell {
     pkgs.xorg.libXcursor
     pkgs.xorg.libXi
     pkgs.xorg.libXrandr
+    pkgs.pipewire
     pkgs.pipewire.jack
   ];
 }

--- a/src/audio_capture.rs
+++ b/src/audio_capture.rs
@@ -1,13 +1,34 @@
-/// Enhanced audio capture with dynamic sample rate detection.
-/// Manages audio streams and adjusts FFT configuration based on actual device capabilities.
+/// Audio capture — backend dispatched per-platform.
+///
+/// `AudioPacket` is the shared frame type that flows from any backend to the
+/// FFT thread via crossbeam channel. The actual `AudioCaptureManager`
+/// implementation lives in:
+///
+/// - `audio_capture_pw` — Linux, native PipeWire via `pipewire-rs` (the
+///   correct backend for capturing what's playing on a sink monitor — cpal's
+///   ALSA path silently misroutes to the default capture source instead).
+/// - this file (cfg(not(linux))) — Windows / macOS, cpal-based with WASAPI /
+///   CoreAudio loopback semantics that work as designed on those platforms.
 
+#[cfg(target_os = "linux")]
+pub use crate::audio_capture_pw::AudioCaptureManager;
+
+use std::time::Instant;
+
+#[cfg(not(target_os = "linux"))]
 use cpal::traits::{DeviceTrait, StreamTrait};
+#[cfg(not(target_os = "linux"))]
 use crossbeam_channel::{bounded, Receiver, Sender};
+#[cfg(not(target_os = "linux"))]
 use std::sync::{Arc, Mutex};
+#[cfg(not(target_os = "linux"))]
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(target_os = "linux"))]
 use std::thread;
-use std::time::{Duration, Instant};
+#[cfg(not(target_os = "linux"))]
+use std::time::Duration;
 
+#[cfg(not(target_os = "linux"))]
 use crate::audio_device::{AudioDeviceEnumerator, AudioDeviceInfo, AudioDeviceError};
 
 /// Audio packet containing raw samples and metadata
@@ -73,73 +94,25 @@ impl AudioPacket {
 }
 
 // ============================================================================
-//  StderrSilencer: Linux Implementation (The real logic)
+//  StderrSilencer (Windows/macOS no-op)
 // ============================================================================
-/// a helper to temporarily silence `stderr` out from C libaries (ALSA, Jack)
-/// Useful on Linux to suppress unwanted error messages from audio backends
-#[cfg(target_os = "linux")]
-struct StderrSilencer {
-    original_stderr: Option<i32>,
-}
-
-#[cfg(target_os = "linux")]
-impl StderrSilencer {
-    fn new() -> Self {
-        let mut silencer = Self { original_stderr: None };
-        unsafe {
-            // 1. Duplicate the current stderr (file descriptor 2) so we can restore it later
-            let stderr_fd = libc::STDERR_FILENO;
-            let original = libc::dup(stderr_fd);
-
-            if original >= 0 {
-                silencer.original_stderr = Some(original);
-
-                // 2. Open /dev/null (the black hole waits for nothing)
-                let null_path = std::ffi::CString::new("/dev/null").unwrap();
-                let null_fd = libc::open(null_path.as_ptr(), libc::O_WRONLY);
-
-                if null_fd >= 0 {
-                    // 3. Overrite  stderr with /dev/null file descriptor
-                    libc::dup2(null_fd, stderr_fd);
-                    libc::close(null_fd);
-                }
-            }
-        }
-        silencer
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl Drop for StderrSilencer {
-    fn drop(&mut self) {
-        // Restore stderr immediately when this struct goes out of scope
-        if let Some(original) = self.original_stderr {
-            unsafe {
-                libc::dup2(original, libc::STDERR_FILENO);
-                libc::close(original);
-            }
-        }
-    }
-}
-
-// ============================================================================
-//  StderrSilencer: Windows/macOS Implementation (Dummy / No-Op)
-// ============================================================================
-// On other platforms, we don't need to suppress anything, so this struct does nothing.
-// The compiler optimizes it away completely (zero cost).
+// Was originally a linux ALSA/JACK stderr suppressor. Now that the linux audio
+// backend is native PipeWire (no cpal, no ALSA), nothing on linux spams stderr
+// and the real impl is gone. The remaining no-op exists so the cpal-based
+// AudioCaptureManager on Windows/macOS keeps the same call shape; the compiler
+// optimizes it away.
 #[cfg(not(target_os = "linux"))]
 struct StderrSilencer;
 
 #[cfg(not(target_os = "linux"))]
 impl StderrSilencer {
     fn new() -> Self {
-        Self // Returns the empty struct
+        Self
     }
 }
 
-
-
 /// Handles audio capture from a specific device
+#[cfg(not(target_os = "linux"))]
 pub struct AudioCaptureManager {
     /// Information about the currently active device
     device_info: Arc<Mutex<AudioDeviceInfo>>,
@@ -157,6 +130,7 @@ pub struct AudioCaptureManager {
     capture_thread: Option<thread::JoinHandle<()>>,
 }
 
+#[cfg(not(target_os = "linux"))]
 impl AudioCaptureManager {
     /// Create a new audio capture manager with default device
     pub fn new() -> Result<Self, AudioDeviceError> {
@@ -492,6 +466,7 @@ impl AudioCaptureManager {
 
 }
 
+#[cfg(not(target_os = "linux"))]
 impl Drop for AudioCaptureManager {
     fn drop(&mut self) {
         self.stop_capture();
@@ -500,7 +475,9 @@ impl Drop for AudioCaptureManager {
 
 // ========== Tests ============
 
-#[cfg(test)]
+// AudioCaptureManager unit tests on cpal-using platforms only. The pipewire
+// linux backend has its own tests.
+#[cfg(all(test, not(target_os = "linux")))]
 mod tests {
     use super::*;
 

--- a/src/audio_capture_pw.rs
+++ b/src/audio_capture_pw.rs
@@ -1,0 +1,908 @@
+//! Linux audio capture backend using native PipeWire (`pipewire-rs`).
+//!
+//! Replaces cpal/ALSA on Linux because cpal's "open the output device, call
+//! `build_input_stream`" pattern is a Windows WASAPI loopback idiom that
+//! silently misroutes on Linux ALSA — it ends up reading from the default
+//! capture *source* (the system mic) instead of the requested sink's monitor.
+//!
+//! This backend creates a PipeWire input stream with `MEDIA_CATEGORY = Capture`
+//! and `STREAM_CAPTURE_SINK = true`. With no explicit target node, PipeWire
+//! auto-connects the stream to the *current default sink's monitor* and
+//! transparently follows default-sink changes — exactly what an audio
+//! visualizer wants. Format is negotiated to interleaved f32 stereo at the
+//! sink's native rate.
+//!
+//! The PipeWire mainloop runs on its own thread; audio frames are forwarded
+//! to the FFT thread via the same `crossbeam_channel<AudioPacket>` the cpal
+//! backend uses, so the rest of bespec is unchanged.
+//!
+//! Implementation cribs from the `audio-capture` example in the upstream
+//! `pipewire-rs` 0.9 crate, with two adaptations: STREAM_CAPTURE_SINK is set
+//! by default (we want sink monitors, not mic input — that's bespec's job),
+//! and the mainloop runs on a dedicated thread with a polling timer that
+//! observes a shutdown atomic for graceful teardown from other threads.
+
+use crossbeam_channel::{bounded, Receiver, Sender};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use pipewire as pw;
+use pw::properties::properties;
+use pw::spa;
+use spa::param::audio::{AudioFormat, AudioInfoRaw};
+use spa::param::format::{MediaSubtype, MediaType};
+use spa::param::format_utils;
+use spa::pod::{serialize::PodSerializer, Object, Pod, Value};
+
+use crate::audio_capture::AudioPacket;
+use crate::audio_device::{AudioDeviceError, AudioDeviceInfo};
+
+/// Default rate / channel layout we request from PipeWire. PipeWire negotiates
+/// down to whatever the default sink actually supports (typically 48000 Hz
+/// stereo) and the actual values come back via the `param_changed` callback
+/// before the first audio packet is delivered.
+const DEFAULT_RATE: u32 = 48000;
+const DEFAULT_CHANNELS: u32 = 2;
+
+/// Bounded channel capacity between the realtime PipeWire process callback
+/// and the FFT thread. Matches the cpal backend's `bounded(16)`.
+const PACKET_QUEUE_SIZE: usize = 16;
+
+/// How often the shutdown atomic is polled from inside the PipeWire mainloop.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Shared metadata between the audio thread (writer) and the manager
+/// (reader). Atomics so there's no locking on the realtime path.
+struct StreamMeta {
+    sample_rate: AtomicU32,
+    channels: AtomicU32,
+}
+
+/// Sentinel id for the "follow the current default sink monitor" virtual
+/// device. This matches the existing cross-platform `"Default"` convention
+/// hard-coded in `main.rs` and `gui/widgets.rs` so there is exactly one
+/// "default device" identifier across all backends. Anything else is
+/// interpreted as a literal PipeWire `node.name`.
+pub const DEFAULT_DEVICE_ID: &str = "Default";
+
+/// Linux audio capture manager. Public surface mirrors the cpal-based
+/// `AudioCaptureManager` so `main.rs` and the GUI don't care which backend
+/// is in use.
+pub struct AudioCaptureManager {
+    device_info: AudioDeviceInfo,
+    /// Currently-selected device id. `DEFAULT_DEVICE_ID` means
+    /// "auto-follow the default sink"; anything else is a PipeWire node
+    /// name that the capture thread resolves at stream-creation time.
+    selected_device: String,
+    tx: Sender<AudioPacket>,
+    rx: Receiver<AudioPacket>,
+    shutdown: Arc<AtomicBool>,
+    meta: Arc<StreamMeta>,
+    capture_thread: Option<thread::JoinHandle<()>>,
+}
+
+impl AudioCaptureManager {
+    /// Construct a manager for the system's default audio — the current
+    /// default sink's monitor, auto-following any default-sink change.
+    pub fn new() -> Result<Self, AudioDeviceError> {
+        Self::with_info(default_device_info(), DEFAULT_DEVICE_ID.to_string())
+    }
+
+    /// Construct a manager for a specific device id. `id` is either the
+    /// `DEFAULT_DEVICE_ID` sentinel or a literal PipeWire `node.name`
+    /// (sink name for monitor capture, or source name for mic / line-in).
+    pub fn with_device_id(device_id: &str) -> Result<Self, AudioDeviceError> {
+        if device_id == DEFAULT_DEVICE_ID {
+            Self::new()
+        } else {
+            Self::with_info(synthetic_info_for_id(device_id), device_id.to_string())
+        }
+    }
+
+    fn with_info(
+        device_info: AudioDeviceInfo,
+        selected_device: impl Into<String>,
+    ) -> Result<Self, AudioDeviceError> {
+        let (tx, rx) = bounded(PACKET_QUEUE_SIZE);
+        Ok(Self {
+            device_info,
+            selected_device: selected_device.into(),
+            tx,
+            rx,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            meta: Arc::new(StreamMeta {
+                sample_rate: AtomicU32::new(DEFAULT_RATE),
+                channels: AtomicU32::new(DEFAULT_CHANNELS),
+            }),
+            capture_thread: None,
+        })
+    }
+
+    /// Enumerate every audio source visible to PipeWire — both physical
+    /// `Audio/Source` nodes (mics, line-ins) and `.monitor` sources of every
+    /// `Audio/Sink` (i.e. one capture point per output device that mirrors
+    /// what's playing on it).
+    ///
+    /// Does *not* include a synthetic "default" entry: the GUI dropdown in
+    /// `gui/widgets.rs` already prepends a hard-coded "Default System Device"
+    /// option for the cross-platform default-device sentinel, and adding our
+    /// own would duplicate it. Returns an empty Vec on registry failure
+    /// rather than an error so the GUI still gets to show the hard-coded
+    /// default option even on a broken PipeWire daemon.
+    pub fn list_devices() -> Result<Vec<AudioDeviceInfo>, AudioDeviceError> {
+        match enumerate_pipewire_sources() {
+            Ok(found) => Ok(found),
+            Err(e) => {
+                tracing::warn!(
+                    "[AudioCapture] PipeWire registry enumeration failed: {} \
+                     (GUI will fall back to the default-device option only)",
+                    e
+                );
+                Ok(Vec::new())
+            }
+        }
+    }
+
+    /// Spawn the PipeWire mainloop on a worker thread and connect a capture
+    /// stream. The thread resolves the selected device name against the live
+    /// PipeWire registry and sets up the stream accordingly: a sink name
+    /// becomes `TARGET_OBJECT` + `STREAM_CAPTURE_SINK = true`; a source name
+    /// becomes plain `TARGET_OBJECT` (no capture-sink); and the
+    /// `DEFAULT_DEVICE_ID` sentinel skips the lookup entirely so the stream
+    /// auto-connects to the current default sink monitor.
+    pub fn start_capture(&mut self) -> Result<(), AudioDeviceError> {
+        let tx = self.tx.clone();
+        let shutdown = Arc::clone(&self.shutdown);
+        let meta = Arc::clone(&self.meta);
+        let selected_device = self.selected_device.clone();
+
+        tracing::info!(
+            "[AudioCapture] Starting PipeWire capture: {}",
+            selected_device,
+        );
+
+        let handle = thread::spawn(move || {
+            if let Err(e) = run_pipewire_loop(tx, shutdown, meta, selected_device) {
+                tracing::error!("[AudioCapture] PipeWire backend error: {}", e);
+            }
+        });
+
+        self.capture_thread = Some(handle);
+        Ok(())
+    }
+
+    /// Signal the PipeWire mainloop to quit and join the worker thread.
+    pub fn stop_capture(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.capture_thread.take() {
+            // Best-effort join. The polling timer inside the pipewire mainloop
+            // sees the atomic flip and quits within ~SHUTDOWN_POLL_INTERVAL.
+            let _ = handle.join();
+        }
+        // Reset for potential restart.
+        self.shutdown.store(false, Ordering::Relaxed);
+    }
+
+    /// Switch the active device. Tears down the current capture stream
+    /// (joining the worker thread) and starts a new one targeting the
+    /// requested PipeWire node by name. The `DEFAULT_DEVICE_ID` sentinel
+    /// switches back to "follow the default sink".
+    pub fn switch_device(&mut self, device_id: &str) -> Result<(), AudioDeviceError> {
+        self.stop_capture();
+        self.selected_device = device_id.to_string();
+        self.device_info = if device_id == DEFAULT_DEVICE_ID {
+            default_device_info()
+        } else {
+            synthetic_info_for_id(device_id)
+        };
+        self.start_capture()
+    }
+
+    /// Receiver end of the audio packet channel. Cloned out to the FFT thread.
+    pub fn receiver(&self) -> Receiver<AudioPacket> {
+        self.rx.clone()
+    }
+
+    #[allow(dead_code)]
+    pub fn device_info(&self) -> AudioDeviceInfo {
+        let mut info = self.device_info.clone();
+        // Surface the actual negotiated rate/channels so consumers see what
+        // the stream is delivering rather than the defaults we requested.
+        info.default_sample_rate = self.meta.sample_rate.load(Ordering::Relaxed);
+        info.channels = self.meta.channels.load(Ordering::Relaxed) as u16;
+        info
+    }
+}
+
+impl Drop for AudioCaptureManager {
+    fn drop(&mut self) {
+        self.stop_capture();
+    }
+}
+
+/// Build the synthetic "System Audio" device descriptor exposed to the GUI
+/// picker. The numbers reflect the format we request from PipeWire; the real
+/// negotiated values surface via `device_info()` after the stream connects.
+fn default_device_info() -> AudioDeviceInfo {
+    AudioDeviceInfo {
+        id: DEFAULT_DEVICE_ID.to_string(),
+        name: "System Audio (Default Output)".to_string(),
+        sample_rates: vec![DEFAULT_RATE],
+        default_sample_rate: DEFAULT_RATE,
+        channels: DEFAULT_CHANNELS as u16,
+        is_default: true,
+    }
+}
+
+/// Build a placeholder `AudioDeviceInfo` for a device id we don't yet have
+/// rich metadata for. Used by `with_device_id` / `switch_device` when the
+/// caller restored a saved selection from disk before `list_devices()` was
+/// called. The id is the literal PipeWire `node.name`; the registry walk
+/// inside `run_pipewire_loop` resolves it to a real node at capture time.
+fn synthetic_info_for_id(device_id: &str) -> AudioDeviceInfo {
+    AudioDeviceInfo {
+        id: device_id.to_string(),
+        name: device_id.to_string(),
+        sample_rates: vec![DEFAULT_RATE],
+        default_sample_rate: DEFAULT_RATE,
+        channels: DEFAULT_CHANNELS as u16,
+        is_default: false,
+    }
+}
+
+/// Per-capture-thread state. Both pipewire callbacks receive `&mut` to this
+/// via the listener's user-data slot; the mainloop ensures they run serially
+/// on the capture thread, so no extra synchronization is needed inside.
+struct CaptureState {
+    tx: Sender<AudioPacket>,
+    meta: Arc<StreamMeta>,
+    format: AudioInfoRaw,
+    /// Set to true by `param_changed` once we've confirmed the negotiated
+    /// format is interleaved F32LE (the only format we ask for + the only
+    /// one `process` knows how to interpret). Until this is true, `process`
+    /// drops every quantum so we never reinterpret bytes under an unknown
+    /// sample type.
+    format_validated: bool,
+    started_logged: bool,
+}
+
+/// What kind of node `selected_device` resolves to in the live PipeWire
+/// registry — drives whether we set `STREAM_CAPTURE_SINK` and whether we
+/// pin a `TARGET_OBJECT`.
+enum ResolvedTarget {
+    /// `DEFAULT_DEVICE_ID` sentinel — let pipewire auto-connect to the
+    /// current default sink monitor.
+    DefaultSink,
+    /// A specific Audio/Sink: target it by name with `STREAM_CAPTURE_SINK`
+    /// to grab the monitor side.
+    SinkMonitor { node_name: String },
+    /// A specific Audio/Source (mic / line-in / loopback): target it
+    /// by name without `STREAM_CAPTURE_SINK`.
+    Source { node_name: String },
+}
+
+/// Run the PipeWire mainloop until `shutdown` is set. Owns the entire
+/// pipewire-rs object graph (mainloop / context / core / stream / listener)
+/// for the duration of the capture session.
+fn run_pipewire_loop(
+    tx: Sender<AudioPacket>,
+    shutdown: Arc<AtomicBool>,
+    meta: Arc<StreamMeta>,
+    selected_device: impl Into<String>,
+) -> Result<(), AudioDeviceError> {
+    let selected_device = selected_device.into();
+    pw::init();
+
+    let mainloop = pw::main_loop::MainLoopRc::new(None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("MainLoopRc::new failed: {e}")))?;
+    let context = pw::context::ContextRc::new(&mainloop, None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("ContextRc::new failed: {e}")))?;
+    let core = context
+        .connect_rc(None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("connect_rc failed: {e}")))?;
+
+    // Resolve the saved device name against the live registry so we know
+    // whether to capture a sink monitor or a plain source. Round-trips on
+    // the same mainloop, ~10ms on a local pipewire socket.
+    let target = if selected_device == DEFAULT_DEVICE_ID {
+        ResolvedTarget::DefaultSink
+    } else {
+        match resolve_target(&mainloop, &core, &selected_device) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    "[AudioCapture] Could not resolve '{}' in PipeWire registry \
+                     ({}); falling back to default sink monitor",
+                    selected_device,
+                    e
+                );
+                ResolvedTarget::DefaultSink
+            }
+        }
+    };
+
+    // Build stream properties based on the resolved target.
+    let mut props = properties! {
+        *pw::keys::MEDIA_TYPE => "Audio",
+        *pw::keys::MEDIA_CATEGORY => "Capture",
+        *pw::keys::MEDIA_ROLE => "Music",
+        *pw::keys::NODE_NAME => "bespec-capture",
+        *pw::keys::NODE_DESCRIPTION => "BeSpec Visualizer Capture",
+    };
+    match &target {
+        ResolvedTarget::DefaultSink => {
+            // No TARGET_OBJECT: pipewire auto-connects to the current default
+            // sink and re-routes on default-sink changes.
+            props.insert(*pw::keys::STREAM_CAPTURE_SINK, "true");
+            tracing::info!("[AudioCapture] Targeting default sink monitor (auto-follow)");
+        }
+        ResolvedTarget::SinkMonitor { node_name } => {
+            props.insert(*pw::keys::STREAM_CAPTURE_SINK, "true");
+            props.insert(*pw::keys::TARGET_OBJECT, node_name.clone());
+            tracing::info!("[AudioCapture] Targeting sink monitor: {}", node_name);
+        }
+        ResolvedTarget::Source { node_name } => {
+            props.insert(*pw::keys::TARGET_OBJECT, node_name.clone());
+            tracing::info!("[AudioCapture] Targeting input source: {}", node_name);
+        }
+    }
+
+    let stream = pw::stream::StreamBox::new(&core, "bespec-capture", props)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("StreamBox::new failed: {e}")))?;
+
+    let user_data = CaptureState {
+        tx,
+        meta: Arc::clone(&meta),
+        format: AudioInfoRaw::new(),
+        format_validated: false,
+        started_logged: false,
+    };
+
+    let _listener = stream
+        .add_local_listener_with_user_data(user_data)
+        .param_changed(|_stream, state, id, param| {
+            // Only react to format negotiation events.
+            let Some(param) = param else { return };
+            if id != pw::spa::param::ParamType::Format.as_raw() {
+                return;
+            }
+
+            // Reject anything that isn't raw audio.
+            let (media_type, media_subtype) = match format_utils::parse_format(param) {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
+                return;
+            }
+
+            // Pull out rate/channels and publish them so the manager (and
+            // therefore the FFT thread, via AudioPacket) sees the real values.
+            if state.format.parse(param).is_ok() {
+                // Only F32LE is safe for the `process` callback's typed
+                // reinterpret — explicitly validate before unblocking it.
+                if state.format.format() != AudioFormat::F32LE {
+                    tracing::error!(
+                        "[AudioCapture] PipeWire negotiated unsupported sample \
+                         format {:?} (expected F32LE); refusing to deliver \
+                         audio. This should not happen — bespec only requests \
+                         F32LE in the format pod.",
+                        state.format.format()
+                    );
+                    state.format_validated = false;
+                    return;
+                }
+                state.format_validated = true;
+                state
+                    .meta
+                    .sample_rate
+                    .store(state.format.rate(), Ordering::Relaxed);
+                state
+                    .meta
+                    .channels
+                    .store(state.format.channels(), Ordering::Relaxed);
+                tracing::info!(
+                    "[AudioCapture] PipeWire format negotiated: {} Hz, {} ch (F32LE)",
+                    state.format.rate(),
+                    state.format.channels()
+                );
+            }
+        })
+        .process(|stream, state| {
+            // Refuse to interpret bytes until param_changed has confirmed
+            // the negotiated format is F32LE. Without this gate, a future
+            // PipeWire change that lands on e.g. S16LE would corrupt the
+            // FFT input (and casting bytes-as-f32 under an unknown sample
+            // type is undefined behavior).
+            if !state.format_validated {
+                return;
+            }
+
+            // Pull one buffer out of the realtime queue. None happens
+            // occasionally under load; the next quantum will catch up.
+            let Some(mut buffer) = stream.dequeue_buffer() else {
+                return;
+            };
+
+            let datas = buffer.datas_mut();
+            if datas.is_empty() {
+                return;
+            }
+            let data = &mut datas[0];
+
+            let n_channels = state.format.channels();
+            if n_channels == 0 {
+                return;
+            }
+
+            let chunk_size = data.chunk().size() as usize;
+            let n_samples = chunk_size / std::mem::size_of::<f32>();
+            if n_samples == 0 {
+                return;
+            }
+
+            let Some(bytes) = data.data() else { return };
+            if bytes.len() < chunk_size {
+                return;
+            }
+
+            // Cast the byte slice to `&[f32]` via `align_to`, which checks
+            // alignment and length safely. PipeWire usually hands us a
+            // properly aligned buffer (the SHM segment is page-aligned and
+            // chunks start on f32 boundaries) but we can't *prove* that
+            // statically, and an unchecked `from_raw_parts` cast on a
+            // misaligned buffer is immediate UB. align_to on an aligned
+            // buffer is zero-cost — it just returns the middle slice.
+            let sample_bytes = &bytes[..chunk_size];
+            // SAFETY: u8 has alignment 1, so reinterpreting any byte slice
+            // as f32 via align_to is well-defined; align_to never produces
+            // unaligned f32 elements. The middle slice is exactly the
+            // longest f32 prefix of the byte buffer with the correct
+            // alignment.
+            let (prefix, samples, suffix) = unsafe { sample_bytes.align_to::<f32>() };
+            if !prefix.is_empty() || !suffix.is_empty() || samples.len() != n_samples {
+                tracing::warn!(
+                    "[AudioCapture] dropping PipeWire quantum with incompatible \
+                     f32 alignment/size (prefix={}, suffix={}, got={}, expected={})",
+                    prefix.len(),
+                    suffix.len(),
+                    samples.len(),
+                    n_samples
+                );
+                return;
+            }
+
+            if !state.started_logged {
+                tracing::info!("[AudioCapture] ✓ PipeWire stream delivering audio");
+                state.started_logged = true;
+            }
+
+            let packet = AudioPacket {
+                samples: samples.to_vec(),
+                sample_rate: state.format.rate(),
+                channels: n_channels as u16,
+                timestamp: Instant::now(),
+            };
+
+            // try_send: if the FFT thread is behind, drop this quantum rather
+            // than block the realtime PipeWire callback. Matches the cpal
+            // backend's behavior under sustained overload.
+            let _ = state.tx.try_send(packet);
+        })
+        .register()
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("listener register failed: {e}")))?;
+
+    // Format param: request f32 LE; leave rate/channels unset so PipeWire
+    // negotiates to the default sink's native format. The actual values come
+    // back via `param_changed` above.
+    let mut audio_info = AudioInfoRaw::new();
+    audio_info.set_format(AudioFormat::F32LE);
+
+    let pod_obj = Object {
+        type_: pw::spa::utils::SpaTypes::ObjectParamFormat.as_raw(),
+        id: pw::spa::param::ParamType::EnumFormat.as_raw(),
+        properties: audio_info.into(),
+    };
+    let pod_bytes: Vec<u8> = PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &Value::Object(pod_obj),
+    )
+    .map_err(|e| AudioDeviceError::PipeWireError(format!("pod serialize failed: {e}")))?
+    .0
+    .into_inner();
+
+    let mut params = [Pod::from_bytes(&pod_bytes)
+        .ok_or_else(|| {
+            AudioDeviceError::PipeWireError(
+                "failed to parse serialized format pod".to_string(),
+            )
+        })?];
+
+    stream
+        .connect(
+            spa::utils::Direction::Input,
+            None, // any node — autoconnect to the default sink monitor
+            pw::stream::StreamFlags::AUTOCONNECT
+                | pw::stream::StreamFlags::MAP_BUFFERS
+                | pw::stream::StreamFlags::RT_PROCESS,
+            &mut params,
+        )
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("stream.connect failed: {e}")))?;
+
+    // Polling timer for graceful shutdown: every ~50ms, check the shutdown
+    // atomic and quit the mainloop when set. The closure runs on the same
+    // thread as the mainloop, so calling .quit() from inside is safe.
+    let mainloop_for_timer = mainloop.clone();
+    let shutdown_for_timer = Arc::clone(&shutdown);
+    let timer = mainloop.loop_().add_timer(move |_expirations| {
+        if shutdown_for_timer.load(Ordering::Relaxed) {
+            mainloop_for_timer.quit();
+        }
+    });
+    timer
+        .update_timer(Some(SHUTDOWN_POLL_INTERVAL), Some(SHUTDOWN_POLL_INTERVAL))
+        .into_result()
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("update_timer failed: {e:?}")))?;
+
+    mainloop.run();
+
+    tracing::info!("[AudioCapture] PipeWire mainloop exited");
+    Ok(())
+}
+
+// ===========================================================================
+//  Registry walk: enumerate every Audio/Source the graph exposes
+// ===========================================================================
+//
+// Stand up a short-lived pipewire connection, walk the registry once via the
+// standard `core.sync` round-trip pattern, collect every node whose
+// `media.class` is `Audio/Source` (covers both physical inputs *and* the
+// `.monitor` source of every Audio/Sink, since pipewire publishes both as
+// Audio/Source globals), turn each into an AudioDeviceInfo, then tear the
+// connection down. Called from `list_devices()` and exposed via the
+// `list-pw-sources` example so devs can inspect the discovered set without
+// rebuilding bespec.
+
+/// Which kind of PipeWire source a `PipewireSource` refers to.
+///
+/// Using an enum instead of a `bool is_monitor` field avoids "boolean
+/// blindness" at call sites — e.g. the test helper reads
+/// `src("...", "...", SourceType::Monitor)` instead of `src("...", "...",
+/// true)` where the reader has to guess what `true` means.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceType {
+    /// The `.monitor` side of an Audio/Sink — captures what's *playing*
+    /// on that sink. Drives picker grouping under "Outputs".
+    Monitor,
+    /// A physical Audio/Source (mic, line-in, virtual capture node).
+    Input,
+}
+
+/// One Audio/Source node as we read it from the PipeWire registry. Kept
+/// public to the crate so the standalone `list-pw-sources` example can
+/// inspect the same data list_devices uses.
+#[derive(Clone, Debug)]
+pub struct PipewireSource {
+    /// Stable node name — the string we pass back as `AudioDeviceInfo.id`
+    /// and later as PipeWire `TARGET_OBJECT` when capturing this source.
+    pub node_name: String,
+    /// Human-readable description (`node.description`), or the node name if
+    /// no description was set.
+    pub description: String,
+    /// Whether this source is a sink monitor (output-side capture) or a
+    /// physical input. Drives picker grouping.
+    pub source_type: SourceType,
+}
+
+impl PipewireSource {
+    /// User-facing label for the GUI device picker. Disambiguates monitor
+    /// sources (output capture) from physical inputs (mic / line-in).
+    pub fn display_name(&self) -> String {
+        let tag = match self.source_type {
+            SourceType::Monitor => "Output Monitor",
+            SourceType::Input => "Input",
+        };
+        format!("{} ({})", self.description, tag)
+    }
+}
+
+/// Walk the PipeWire registry once and return every `Audio/Source` node.
+///
+/// Uses the round-trip pattern from `pipewire-rs/examples/roundtrip.rs`:
+/// fire `core.sync(0)`, drive the mainloop until the matching `done` event
+/// arrives, tear everything down. The whole thing typically completes in a
+/// few milliseconds on a local pipewire socket.
+pub fn enumerate_pipewire_sources() -> Result<Vec<AudioDeviceInfo>, AudioDeviceError> {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    pw::init();
+
+    let mainloop = pw::main_loop::MainLoopRc::new(None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("MainLoopRc::new failed: {e}")))?;
+    let context = pw::context::ContextRc::new(&mainloop, None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("ContextRc::new failed: {e}")))?;
+    let core = context
+        .connect_rc(None)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("connect_rc failed: {e}")))?;
+    let registry = core
+        .get_registry_rc()
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("get_registry_rc failed: {e}")))?;
+
+    let sources: Rc<RefCell<Vec<PipewireSource>>> = Rc::new(RefCell::new(Vec::new()));
+    let sources_for_global = Rc::clone(&sources);
+
+    // Fire the sync request *before* installing the done listener so the
+    // closures don't have to capture the seq number through a Cell.
+    let pending = core
+        .sync(0)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("core.sync failed: {e}")))?;
+
+    let done = Rc::new(std::cell::Cell::new(false));
+    let done_for_listener = Rc::clone(&done);
+    let mainloop_for_listener = mainloop.clone();
+
+    let _core_listener = core
+        .add_listener_local()
+        .done(move |id, seq| {
+            if id == pw::core::PW_ID_CORE && seq == pending {
+                done_for_listener.set(true);
+                mainloop_for_listener.quit();
+            }
+        })
+        .register();
+
+    let _registry_listener = registry
+        .add_listener_local()
+        .global(move |obj| {
+            if obj.type_ != pw::types::ObjectType::Node {
+                return;
+            }
+            let Some(props) = obj.props.as_ref() else {
+                return;
+            };
+            let Some(media_class) = props.get("media.class") else {
+                return;
+            };
+            let Some(node_name) = props.get("node.name") else {
+                return;
+            };
+            let description = props
+                .get("node.description")
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| node_name.to_string());
+
+            match media_class {
+                // Physical inputs and any monitors that pipewire-pulse
+                // happens to materialize as standalone source globals.
+                "Audio/Source" => {
+                    let source_type = if node_name.ends_with(".monitor") {
+                        SourceType::Monitor
+                    } else {
+                        SourceType::Input
+                    };
+                    sources_for_global.borrow_mut().push(PipewireSource {
+                        node_name: node_name.to_string(),
+                        description,
+                        source_type,
+                    });
+                }
+                // Sinks: synthesize a monitor entry. PipeWire doesn't publish
+                // monitors as standalone Audio/Source globals — the monitor
+                // is an implicit aspect of the sink, reached by targeting the
+                // sink's node name with STREAM_CAPTURE_SINK = true at capture
+                // time. Storing the sink name (no `.monitor` suffix) lets us
+                // pass it as TARGET_OBJECT directly later.
+                "Audio/Sink" => {
+                    sources_for_global.borrow_mut().push(PipewireSource {
+                        node_name: node_name.to_string(),
+                        description,
+                        source_type: SourceType::Monitor,
+                    });
+                }
+                _ => {}
+            }
+        })
+        .register();
+
+    // Drive the loop until the done callback flips the flag. The roundtrip
+    // example wraps this in `while !done.get() { mainloop.run(); }` because
+    // pipewire-rs may return early under some signal-handling conditions.
+    while !done.get() {
+        mainloop.run();
+    }
+
+    // Stable ordering — monitors first (visualizer-typical default), then
+    // inputs, each section sorted by description so the picker is
+    // predictable across runs.
+    //
+    // We clone out of the Rc<RefCell<>> rather than `try_unwrap`-ing it,
+    // because the registry/core listener closures still hold their own clones
+    // of the same Rc until they're dropped at end-of-function.
+    let mut sources = sources.borrow().clone();
+    sources.sort_by(|a, b| {
+        // Monitors before Inputs: reverse-sort on the boolean-equivalent
+        // "is this a monitor" — `SourceType` is ordered via derived Ord? No,
+        // we only derive PartialEq/Eq, so compare explicitly.
+        let a_is_mon = matches!(a.source_type, SourceType::Monitor);
+        let b_is_mon = matches!(b.source_type, SourceType::Monitor);
+        b_is_mon
+            .cmp(&a_is_mon)
+            .then_with(|| a.description.cmp(&b.description))
+    });
+
+    Ok(sources.into_iter().map(source_to_device_info).collect())
+}
+
+/// Convert a discovered `PipewireSource` into the cross-platform
+/// `AudioDeviceInfo` shape the GUI device picker consumes.
+fn source_to_device_info(source: PipewireSource) -> AudioDeviceInfo {
+    AudioDeviceInfo {
+        id: source.node_name.clone(),
+        name: source.display_name(),
+        sample_rates: vec![DEFAULT_RATE],
+        default_sample_rate: DEFAULT_RATE,
+        channels: DEFAULT_CHANNELS as u16,
+        is_default: false,
+    }
+}
+
+/// Walk the PipeWire registry on an existing core and figure out whether
+/// `node_name` refers to an Audio/Sink (so we capture its monitor) or an
+/// Audio/Source (so we capture it directly). Reuses the same mainloop the
+/// caller is about to drive for capture, so this only adds one extra
+/// roundtrip per session.
+fn resolve_target(
+    mainloop: &pw::main_loop::MainLoopRc,
+    core: &pw::core::CoreRc,
+    node_name: &str,
+) -> Result<ResolvedTarget, AudioDeviceError> {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    let registry = core
+        .get_registry_rc()
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("get_registry_rc failed: {e}")))?;
+
+    // (is_sink, is_source) populated by the registry walk.
+    let found: Rc<RefCell<Option<bool>>> = Rc::new(RefCell::new(None));
+    let found_for_listener = Rc::clone(&found);
+    let target_name = node_name.to_string();
+
+    let pending = core
+        .sync(0)
+        .map_err(|e| AudioDeviceError::PipeWireError(format!("core.sync failed: {e}")))?;
+    let done = Rc::new(Cell::new(false));
+    let done_for_listener = Rc::clone(&done);
+    let mainloop_for_listener = mainloop.clone();
+
+    let _core_listener = core
+        .add_listener_local()
+        .done(move |id, seq| {
+            if id == pw::core::PW_ID_CORE && seq == pending {
+                done_for_listener.set(true);
+                mainloop_for_listener.quit();
+            }
+        })
+        .register();
+
+    let _registry_listener = registry
+        .add_listener_local()
+        .global(move |obj| {
+            if obj.type_ != pw::types::ObjectType::Node {
+                return;
+            }
+            let Some(props) = obj.props.as_ref() else {
+                return;
+            };
+            if props.get("node.name") != Some(target_name.as_str()) {
+                return;
+            }
+            match props.get("media.class") {
+                Some("Audio/Sink") => *found_for_listener.borrow_mut() = Some(true),
+                Some("Audio/Source") => *found_for_listener.borrow_mut() = Some(false),
+                _ => {}
+            }
+        })
+        .register();
+
+    while !done.get() {
+        mainloop.run();
+    }
+
+    // Copy the value out of the RefCell into a local before the match so the
+    // temporary `Ref` doesn't get held across the closing brace and trip
+    // borrow-checker NLL.
+    let result = *found.borrow();
+    match result {
+        Some(true) => Ok(ResolvedTarget::SinkMonitor {
+            node_name: node_name.to_string(),
+        }),
+        Some(false) => Ok(ResolvedTarget::Source {
+            node_name: node_name.to_string(),
+        }),
+        None => Err(AudioDeviceError::PipeWireError(format!(
+            "node '{node_name}' not present in registry"
+        ))),
+    }
+}
+
+// ===========================================================================
+//  Unit tests
+// ===========================================================================
+//
+// These cover the pure data-shaping logic that doesn't need a live PipeWire
+// daemon: display labelling, the conversion to AudioDeviceInfo, and the
+// sort key used for the GUI dropdown ordering. The actual capture path is
+// integration-tested by running bespec against a real session.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn src(name: &str, desc: &str, source_type: SourceType) -> PipewireSource {
+        PipewireSource {
+            node_name: name.to_string(),
+            description: desc.to_string(),
+            source_type,
+        }
+    }
+
+    #[test]
+    fn display_name_tags_monitors_and_inputs_distinctly() {
+        let mon = src("alsa_output.foo", "Foo Card", SourceType::Monitor);
+        let inp = src("alsa_input.foo", "Foo Card", SourceType::Input);
+        assert_eq!(mon.display_name(), "Foo Card (Output Monitor)");
+        assert_eq!(inp.display_name(), "Foo Card (Input)");
+    }
+
+    #[test]
+    fn source_to_device_info_preserves_node_name_as_id() {
+        let s = src("alsa_output.bar.analog-stereo", "Bar Sink", SourceType::Monitor);
+        let info = source_to_device_info(s);
+        assert_eq!(info.id, "alsa_output.bar.analog-stereo");
+        assert_eq!(info.name, "Bar Sink (Output Monitor)");
+        assert!(!info.is_default);
+        assert_eq!(info.channels, DEFAULT_CHANNELS as u16);
+        assert_eq!(info.default_sample_rate, DEFAULT_RATE);
+    }
+
+    #[test]
+    fn synthetic_info_for_id_round_trips_node_name() {
+        let info = synthetic_info_for_id("alsa_output.usb-foo.analog-stereo");
+        assert_eq!(info.id, "alsa_output.usb-foo.analog-stereo");
+        assert_eq!(info.name, "alsa_output.usb-foo.analog-stereo");
+        assert!(!info.is_default);
+    }
+
+    #[test]
+    fn default_device_info_uses_sentinel_id() {
+        let info = default_device_info();
+        assert_eq!(info.id, DEFAULT_DEVICE_ID);
+        assert!(info.is_default);
+    }
+
+    #[test]
+    fn sources_sort_monitors_first_then_alphabetical() {
+        // Mirrors the comparator in `enumerate_pipewire_sources`: monitors
+        // before inputs, each section sorted by description.
+        let mut entries = vec![
+            src("alsa_input.b", "Bravo Mic", SourceType::Input),
+            src("alsa_output.a", "Alpha Sink", SourceType::Monitor),
+            src("alsa_input.a", "Alpha Mic", SourceType::Input),
+            src("alsa_output.b", "Bravo Sink", SourceType::Monitor),
+        ];
+        entries.sort_by(|a, b| {
+            let a_is_mon = matches!(a.source_type, SourceType::Monitor);
+            let b_is_mon = matches!(b.source_type, SourceType::Monitor);
+            b_is_mon
+                .cmp(&a_is_mon)
+                .then_with(|| a.description.cmp(&b.description))
+        });
+        let order: Vec<&str> = entries.iter().map(|s| s.description.as_str()).collect();
+        assert_eq!(order, vec!["Alpha Sink", "Bravo Sink", "Alpha Mic", "Bravo Mic"]);
+    }
+}
+

--- a/src/audio_device.rs
+++ b/src/audio_device.rs
@@ -1,7 +1,9 @@
 /// Audio device enumeration and stream management.
 /// Handles device discovery, sample rate detection, and dynamic device switching.
 
+#[cfg(not(target_os = "linux"))]
 use cpal::traits::{DeviceTrait, HostTrait};
+#[cfg(not(target_os = "linux"))]
 use cpal::Device;
 use std::fmt;
 
@@ -40,6 +42,9 @@ impl fmt::Display for AudioDeviceInfo {
 }
 
 /// Error types for audio device operations
+// dead_code allowed: linux backend only constructs `DeviceNotFound` today;
+// the rest exist for the cpal backends and for forward-compat error reporting.
+#[allow(dead_code)]
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum AudioDeviceError {
     /// No audio output devices were found on the system.
@@ -57,11 +62,65 @@ pub enum AudioDeviceError {
     /// Failed to query or apply device configuration.
     #[error("Configuration error: {0}")]
     ConfigurationError(String),
+    /// PipeWire backend (Linux) hit an error. The inner string carries the
+    /// context needed to diagnose it — pipewire-rs `Error`, a PipeWire
+    /// pod-serialization failure, a mainloop/context setup failure, etc.
+    #[error("PipeWire backend error: {0}")]
+    PipeWireError(String),
 }
 
 /// Enumerates all available audio output devices and their capabilities
 pub struct AudioDeviceEnumerator;
 
+// ============================================================================
+// Linux: PipeWire-native compatibility shim
+// ============================================================================
+// On linux the audio backend is native PipeWire and the *real* device list
+// comes from `audio_capture_pw::AudioCaptureManager::list_devices()`, which
+// walks the PipeWire registry and returns one entry per Audio/Source plus
+// one synthesized monitor entry per Audio/Sink.
+//
+// This `AudioDeviceEnumerator` impl is just a compatibility shim for the
+// few call sites in `main.rs` that still go through it (e.g. `Default`
+// resolution); it returns a single placeholder representing the current
+// default-sink monitor. Linux callers should prefer
+// `AudioCaptureManager::list_devices()` for actual enumeration.
+//
+// dead_code allowed: most linux callers use `AudioCaptureManager` directly,
+// but we keep the methods here for shape parity with the cpal backends so
+// `main.rs` doesn't need its own cfg-gates around device-list calls.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+impl AudioDeviceEnumerator {
+    pub fn enumerate_devices() -> Result<Vec<AudioDeviceInfo>, AudioDeviceError> {
+        Ok(vec![Self::default_info()])
+    }
+
+    pub fn get_device_by_id(_device_id: &str) -> Result<(), AudioDeviceError> {
+        // Linux backend ignores device id and always captures the default
+        // sink monitor; we just acknowledge any id as valid.
+        Ok(())
+    }
+
+    pub fn get_default_device() -> Result<((), AudioDeviceInfo), AudioDeviceError> {
+        // Tuple shape kept to match call sites in main.rs that destructure
+        // `let (_, info) = ...`.
+        Ok(((), Self::default_info()))
+    }
+
+    fn default_info() -> AudioDeviceInfo {
+        AudioDeviceInfo {
+            id: "System Audio".to_string(),
+            name: "System Audio (Default Output)".to_string(),
+            sample_rates: vec![48000],
+            default_sample_rate: 48000,
+            channels: 2,
+            is_default: true,
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
 impl AudioDeviceEnumerator {
     /// Get all available audio output devices.
     #[must_use = "device list should be checked for errors"]
@@ -238,7 +297,10 @@ impl AudioDeviceEnumerator {
 
 // ================== Tests ===================
 
-#[cfg(test)]
+// Cpal-backed enumerator tests are non-linux only — the linux backend has no
+// cpal symbols in scope. Linux-side enumeration tests live alongside the
+// pipewire backend.
+#[cfg(all(test, not(target_os = "linux")))]
 mod tests {
     use super::*;
 

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -730,30 +730,55 @@ pub fn settings_tab_audio(ui: &mut egui::Ui, state: &mut SharedState) {
                 ui.label("Device");
                 
                 ui.horizontal(|ui| {
-                    let (current_sel, devices) = {
+                    let (current_sel_id, devices) = {
                         (state.config.selected_device.clone(), state.audio_devices.clone())
+                    };
+
+                    // Display label for the currently-selected id: look the id
+                    // up in the device list so the dropdown shows the friendly
+                    // `name` field rather than the raw backend id (which on
+                    // linux is a long pipewire `node.name`). Falls back to the
+                    // id itself for the "Default" sentinel and for ids that
+                    // are no longer present in the list.
+                    //
+                    // `&str` instead of owning `String` — avoids the per-frame
+                    // allocation in the GUI render loop (the dropdown redraws
+                    // every frame). egui's `ComboBox::selected_text` takes
+                    // `impl Into<WidgetText>`, which accepts `&str` directly.
+                    let current_label: &str = if current_sel_id == "Default" {
+                        "Default System Device"
+                    } else {
+                        devices
+                            .iter()
+                            .find(|d| d.id == current_sel_id)
+                            .map(|d| d.name.as_str())
+                            .unwrap_or(current_sel_id.as_str())
                     };
 
                     // Device Selector
                     egui::ComboBox::from_id_salt("audio_device_combo")
-                        .selected_text(&current_sel)
+                        .selected_text(current_label)
                         .width(220.0)
                         .show_ui(ui, |ui| {
                             // Default Option
-                            if ui.selectable_label(current_sel == "Default", "Default System Device").clicked() {
+                            if ui.selectable_label(current_sel_id == "Default", "Default System Device").clicked() {
                                 tracing::info!("[GUI] User selected device: Default");
                                 state.config.selected_device = "Default".to_string();
                                 state.device_changed = true;
                             }
-                            
+
                             ui.separator();
 
-                            // Enumerated Hardware Devices
-                            for name in devices {
-                                let is_selected = current_sel == name;
-                                if ui.selectable_label(is_selected, &name).clicked() {
-                                    tracing::info!("[GUI] User selected device: '{}'", name);
-                                    state.config.selected_device = name;
+                            // Enumerated Hardware Devices: display `name`,
+                            // store `id` in selected_device.
+                            for dev in devices {
+                                let is_selected = current_sel_id == dev.id;
+                                if ui.selectable_label(is_selected, &dev.name).clicked() {
+                                    tracing::info!(
+                                        "[GUI] User selected device: '{}' (id: {})",
+                                        dev.name, dev.id
+                                    );
+                                    state.config.selected_device = dev.id.clone();
                                     state.device_changed = true;
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console on Windows in release
 
 mod audio_capture;
+#[cfg(target_os = "linux")]
+mod audio_capture_pw;
 mod audio_device;
 mod fft_config;
 mod fft_processor;
@@ -65,11 +67,11 @@ fn start_audio_capture(
         tracing::info!("[Capture] Initializing audio device list...");
         if let Ok(devices) = AudioCaptureManager::list_devices() {
             if let Ok(mut state) = shared_state.lock() {
-                state.audio_devices = devices.iter().map(|d| d.name.clone()).collect();
+                state.audio_devices = devices;
 
                 tracing::info!("[Capture] Found {} audio devices", state.audio_devices.len());
-                for (i, name) in state.audio_devices.iter().enumerate() {
-                    tracing::debug!("[Capture]    {}: {}", i, name);
+                for (i, dev) in state.audio_devices.iter().enumerate() {
+                    tracing::debug!("[Capture]    {}: {} ({})", i, dev.name, dev.id);
                 }
             } else {
                 tracing::error!("[Capture] Failed to lock shared state for audio devices");
@@ -140,7 +142,7 @@ fn start_audio_capture(
 
                 if let Ok(devices) = AudioCaptureManager::list_devices() {
                     if let Ok(mut state) = shared_state.lock() {
-                        state.audio_devices = devices.iter().map(|d| d.name.clone()).collect();
+                        state.audio_devices = devices;
                         tracing::info!("[Capture] ✓ Scan complete in {:.2}ms, Found {} audio devices",
                             start.elapsed().as_secs_f32() * 1000.0,
                             state.audio_devices.len()

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -1,4 +1,5 @@
 use std::time::{Duration, Instant};
+use crate::audio_device::AudioDeviceInfo;
 use crate::fft_config::FFTInfo;
 use serde::{Serialize, Deserialize};
 use std::fs;
@@ -264,7 +265,14 @@ pub struct SharedState {
     pub config: AppConfig,
 
     // === Audio Device State === 
-    pub audio_devices: Vec<String>,
+    /// Available audio devices, populated by the capture thread from
+    /// `AudioCaptureManager::list_devices()`. Stores the full
+    /// `AudioDeviceInfo` so the GUI can show the friendly `name` while
+    /// passing the stable `id` back to the backend on selection — these
+    /// are the same string on cpal-based platforms but diverge on linux
+    /// where `id` is the PipeWire `node.name` and `name` is the picker
+    /// label like "Maonocaster E2 (Output Monitor)".
+    pub audio_devices: Vec<AudioDeviceInfo>,
 
     /// Flag: GUI requested a device switch (handled by main thread)
     pub device_changed: bool,


### PR DESCRIPTION
## Problem

On Linux, BeSpec's audio capture goes through `cpal` and uses `host.output_devices()` + `device.build_input_stream()` — the **Windows WASAPI loopback idiom**. On Linux ALSA there's no symmetric semantic, so the call silently routes to the system's default *capture source* (the mic) instead of the requested sink's monitor. BeSpec on Linux therefore looks like it's running but visualizes silence from an unused mic jack. (`cava` works on the same systems because it uses native PipeWire and explicitly targets `<sink>:monitor_FL/FR`.)

## Fix

Replace the Linux audio backend with native `pipewire-rs`. Windows / macOS keep `cpal` unchanged.

- `cpal` becomes non-Linux only; `pipewire = { version = "0.9", features = ["v0_3_44"] }` added Linux-only.
- New `src/audio_capture_pw.rs`: PipeWire mainloop on a worker thread, polling-timer shutdown, audio frames flow through the same `crossbeam_channel<AudioPacket>` the cpal backend used (FFT thread unchanged).
- Stream uses `MEDIA_CATEGORY=Capture` + `STREAM_CAPTURE_SINK=true`, so it auto-connects to the current default sink monitor and follows default-sink changes.
- Registry walk enumerates every `Audio/Source` (mic / line-in) and synthesizes a monitor entry per `Audio/Sink`. `switch_device` re-resolves the picked node and sets `TARGET_OBJECT` (+ `STREAM_CAPTURE_SINK` for sinks).
- Required prerequisite: promote `audio_devices: Vec<String>` → `Vec<AudioDeviceInfo>` so the picker can store stable `id` while displaying `name`. The previous `Vec<String>` worked on cpal because cpal's name *is* its id, but on Linux `id` (PipeWire `node.name`) and `name` (display label) legitimately diverge.
- `examples/list-pw-sources.rs`: standalone diagnostic, `cargo run --release --example list-pw-sources`.

## Test plan

- [x] `cargo build --release` / `cargo test --release` clean
- [x] Verified on NixOS / PipeWire 1.6.2: bespec's stream node links to the active sink's `monitor_FL/FR` ports (same wiring `cava` produces)
- [x] Picker shows enumerated sinks + sources; selecting a non-default sink switches the wpctl wiring in real time
- [x] Switching the system default sink via `wpctl set-default` while bespec is on "Default" auto-reroutes